### PR TITLE
test: reach 100% branch coverage + clear Codacy Python lint findings

### DIFF
--- a/swgb_save.py
+++ b/swgb_save.py
@@ -10,7 +10,6 @@ import zlib
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple
 
-
 PLAYER_PATTERN = bytes.fromhex("16db00000021")
 NAME_SEARCH_WINDOW = 512
 MAX_NAME_BYTES = 32
@@ -85,11 +84,10 @@ class SaveGame:
         """Create a hex dump of bytes with ASCII representation."""
         result = []
         for index in range(0, min(len(data), length), 16):
-            chunk = data[index : index + 16]
+            chunk = data[index:index + 16]
             hex_part = " ".join(f"{byte:02x}" for byte in chunk).ljust(48)
             ascii_part = "".join(
-                chr(byte) if 32 <= byte <= 126 else "." for byte in chunk
-            )
+                chr(byte) if 32 <= byte <= 126 else "." for byte in chunk)
             result.append(f"{offset + index:08x}: {hex_part} |{ascii_part}|")
         return "\n".join(result)
 
@@ -106,26 +104,17 @@ class SaveGame:
 
     @staticmethod
     def _is_name_byte(byte_value: int) -> bool:
-        return (
-            byte_value == 32
-            or 48 <= byte_value <= 57
-            or 65 <= byte_value <= 90
-            or 97 <= byte_value <= 122
-        )
+        return (byte_value == 32 or 48 <= byte_value <= 57
+                or 65 <= byte_value <= 90 or 97 <= byte_value <= 122)
 
     @staticmethod
     def _is_valid_candidate_name(candidate: str, min_length: int) -> bool:
-        return (
-            len(candidate) >= min_length
-            and candidate.isprintable()
-            and all(
-                character.isalnum() or character.isspace() for character in candidate
-            )
-        )
+        return (len(candidate) >= min_length and candidate.isprintable()
+                and all(character.isalnum() or character.isspace()
+                        for character in candidate))
 
-    def _decode_candidate_name(
-        self, start: int, end: int, *, min_length: int
-    ) -> Optional[str]:
+    def _decode_candidate_name(self, start: int, end: int, *,
+                               min_length: int) -> Optional[str]:
         if self.data is None or end <= start:
             return None
         try:
@@ -143,11 +132,12 @@ class SaveGame:
             return None
         name_start = offset + 2
         name_end = self._find_null_terminated_end(name_start, search_end)
-        return self._decode_candidate_name(
-            name_start, name_end, min_length=MIN_MARKER_NAME_LENGTH
-        )
+        return self._decode_candidate_name(name_start,
+                                           name_end,
+                                           min_length=MIN_MARKER_NAME_LENGTH)
 
-    def _name_from_direct_scan(self, offset: int, search_end: int) -> Optional[str]:
+    def _name_from_direct_scan(self, offset: int,
+                               search_end: int) -> Optional[str]:
         if self.data is None or offset + MIN_DIRECT_NAME_LENGTH > search_end:
             return None
         name_end = offset
@@ -159,9 +149,9 @@ class SaveGame:
             if not self._is_name_byte(current_byte):
                 break
             name_end += 1
-        return self._decode_candidate_name(
-            offset, name_end, min_length=MIN_DIRECT_NAME_LENGTH
-        )
+        return self._decode_candidate_name(offset,
+                                           name_end,
+                                           min_length=MIN_DIRECT_NAME_LENGTH)
 
     def _find_name_before_pattern(
         self,
@@ -175,7 +165,8 @@ class SaveGame:
         for offset in range(search_start, search_end - 1):
             marker_name = self._name_from_marker(offset, search_end)
             if marker_name:
-                print(f"{marker_prefix} '{marker_name}' at offset {offset + 2}")
+                print(
+                    f"{marker_prefix} '{marker_name}' at offset {offset + 2}")
                 return marker_name
             direct_name = self._name_from_direct_scan(offset, search_end)
             if direct_name:
@@ -189,9 +180,8 @@ class SaveGame:
         resource_start = pattern_pos + len(PLAYER_PATTERN)
         values: List[float] = []
         for index in range(RESOURCE_COUNT):
-            chunk = self.data[
-                resource_start + index * 4 : resource_start + (index + 1) * 4
-            ]
+            chunk = self.data[resource_start + index * 4:resource_start +
+                              (index + 1) * 4]
             try:
                 value = struct.unpack("<f", chunk)[0]
             except struct.error:
@@ -205,9 +195,8 @@ class SaveGame:
     def _reorder_resources(values: List[float]) -> List[float]:
         return [values[1], values[0], values[2], values[3]]
 
-    def _build_entry(
-        self, pattern_pos: int, name: str, player_num: int
-    ) -> Tuple[int, str, int, bytes]:
+    def _build_entry(self, pattern_pos: int, name: str,
+                     player_num: int) -> Tuple[int, str, int, bytes]:
         if self.data is None:
             return pattern_pos, name, player_num, b""
         resource_start = pattern_pos + len(PLAYER_PATTERN)
@@ -215,7 +204,7 @@ class SaveGame:
             pattern_pos,
             name,
             player_num,
-            self.data[resource_start : resource_start + RESOURCE_COUNT * 4],
+            self.data[resource_start:resource_start + RESOURCE_COUNT * 4],
         )
 
     def _find_player_entries(self) -> List[Tuple[int, str, int, bytes]]:
@@ -238,8 +227,8 @@ class SaveGame:
             print(f"\nFound pattern at offset {pattern_pos}")
             print("Context (64 bytes):")
             print(
-                self._hex_dump(self.data[pattern_pos : pattern_pos + 64], pattern_pos)
-            )
+                self._hex_dump(self.data[pattern_pos:pattern_pos + 64],
+                               pattern_pos))
 
             try:
                 values = self._read_resource_values(pattern_pos)
@@ -260,14 +249,14 @@ class SaveGame:
                 print(f"Resources: {values}")
                 print("Context:")
                 print(
-                    self._hex_dump(
-                        self.data[pattern_pos : pattern_pos + 32], pattern_pos
-                    )
-                )
+                    self._hex_dump(self.data[pattern_pos:pattern_pos + 32],
+                                   pattern_pos))
 
-                player = Player(name, player_num, self._reorder_resources(values))
+                player = Player(name, player_num,
+                                self._reorder_resources(values))
                 self.players.append(player)
-                entries.append(self._build_entry(pattern_pos, name, player_num))
+                entries.append(self._build_entry(pattern_pos, name,
+                                                 player_num))
             except PLAYER_ENTRY_ERRORS as exc:
                 print(f"Error processing pattern at {pattern_pos}: {exc}")
 
@@ -275,33 +264,30 @@ class SaveGame:
 
         return entries
 
-    def _match_player(
-        self, candidate_name: str, updated_players: Set[str]
-    ) -> Optional[Player]:
+    def _match_player(self, candidate_name: str,
+                      updated_players: Set[str]) -> Optional[Player]:
         for player in self.players:
             if player.name == candidate_name and player.name not in updated_players:
                 return player
         return None
 
     @staticmethod
-    def _write_resources(
-        data: bytearray, resource_start: int, resources: List[float]
-    ) -> None:
+    def _write_resources(data: bytearray, resource_start: int,
+                         resources: List[float]) -> None:
         for index, value in enumerate(resources):
             value_bytes = struct.pack("<f", value)
-            data[resource_start + index * 4 : resource_start + (index + 1) * 4] = (
-                value_bytes
-            )
+            data[resource_start + index * 4:resource_start +
+                 (index + 1) * 4] = (value_bytes)
 
     @staticmethod
-    def _verify_written_resources(
-        data: bytearray, resource_start: int, resources: List[float]
-    ) -> None:
+    def _verify_written_resources(data: bytearray, resource_start: int,
+                                  resources: List[float]) -> None:
         print("\nVerifying resource values:")
         for index, expected_value in enumerate(resources):
             actual_value = struct.unpack(
                 "<f",
-                data[resource_start + index * 4 : resource_start + (index + 1) * 4],
+                data[resource_start + index * 4:resource_start +
+                     (index + 1) * 4],
             )[0]
             print(
                 f"Resource {index}: Expected {expected_value:,.0f}, Got {actual_value:,.0f}"
@@ -309,9 +295,8 @@ class SaveGame:
             if abs(actual_value - expected_value) > 0.01:
                 print("WARNING: Resource value mismatch!")
 
-    def _update_matching_player(
-        self, pattern_pos: int, data: bytearray, updated_players: Set[str]
-    ) -> bool:
+    def _update_matching_player(self, pattern_pos: int, data: bytearray,
+                                updated_players: Set[str]) -> bool:
         candidate_name = self._find_name_before_pattern(
             pattern_pos,
             default_name="",
@@ -333,15 +318,13 @@ class SaveGame:
         print(f"Updating resources at offset {resource_start}")
         print("Before update:")
         print(
-            self._hex_dump(
-                self.data[resource_start : resource_start + 16], resource_start
-            )
-        )
+            self._hex_dump(self.data[resource_start:resource_start + 16],
+                           resource_start))
         self._write_resources(data, resource_start, player.resources)
         print("After update:")
         print(
-            self._hex_dump(data[resource_start : resource_start + 16], resource_start)
-        )
+            self._hex_dump(data[resource_start:resource_start + 16],
+                           resource_start))
         self._verify_written_resources(data, resource_start, player.resources)
         updated_players.add(player.name)
         return True
@@ -359,17 +342,22 @@ class SaveGame:
             if pattern_pos == -1:
                 break
             try:
-                self._update_matching_player(pattern_pos, data, updated_players)
+                self._update_matching_player(pattern_pos, data,
+                                             updated_players)
             except PLAYER_ENTRY_ERRORS as exc:
-                print(f"Warning: Error processing pattern at {pattern_pos}: {exc}")
+                print(
+                    f"Warning: Error processing pattern at {pattern_pos}: {exc}"
+                )
             pos = pattern_pos + 1
 
         return updated_players
 
     def _report_missing_updates(self, updated_players: Set[str]) -> None:
         if len(updated_players) != len(self.players):
-            missing = {player.name for player in self.players} - updated_players
-            print(f"Warning: Could not update resources for players: {missing}")
+            missing = {player.name
+                       for player in self.players} - updated_players
+            print(
+                f"Warning: Could not update resources for players: {missing}")
 
     @staticmethod
     def _create_backup_if_missing(filename: str) -> None:
@@ -410,7 +398,8 @@ class SaveGame:
             raise ValueError(NO_SAVE_DATA_LOADED)
 
         try:
-            compressed = self._compress_save_data(self.data, wbits=self.wbits or -15)
+            compressed = self._compress_save_data(self.data,
+                                                  wbits=self.wbits or -15)
             print(f"Original size: {len(original):,} bytes")
             print(f"Compressed size: {len(compressed):,} bytes")
             self._write_compressed_file(filename, compressed)

--- a/swgb_save.py
+++ b/swgb_save.py
@@ -80,7 +80,8 @@ class SaveGame:
         if not self.players:
             print("Could not find any player entries")
 
-    def _hex_dump(self, data: bytes, offset: int = 0, length: int = 64) -> str:
+    @staticmethod
+    def _hex_dump(data: bytes, offset: int = 0, length: int = 64) -> str:
         """Create a hex dump of bytes with ASCII representation."""
         result = []
         for index in range(0, min(len(data), length), 16):

--- a/swgb_save_gui.py
+++ b/swgb_save_gui.py
@@ -34,17 +34,17 @@ class EditResourceDialog:
         self.entries = {}
         # Resources in player object are [wood, food, nova, ore]
         # But display them as [carbon, food, nova, ore]
-        for i, (resource, value) in enumerate(
-            [
-                ("Carbon", resources[0]),
-                ("Food", resources[1]),
-                ("Nova", resources[2]),
-                ("Ore", resources[3]),
-            ]
-        ):
-            ttk.Label(self.dialog, text=f"{resource}:").grid(
-                row=i, column=0, padx=5, pady=5, sticky="e"
-            )
+        for i, (resource, value) in enumerate([
+            ("Carbon", resources[0]),
+            ("Food", resources[1]),
+            ("Nova", resources[2]),
+            ("Ore", resources[3]),
+        ]):
+            ttk.Label(self.dialog, text=f"{resource}:").grid(row=i,
+                                                             column=0,
+                                                             padx=5,
+                                                             pady=5,
+                                                             sticky="e")
             var = tk.StringVar(value=f"{value:,.0f}")
             entry = ttk.Entry(self.dialog, textvariable=var)
             entry.grid(row=i, column=1, padx=5, pady=5, sticky="ew")
@@ -54,10 +54,10 @@ class EditResourceDialog:
         button_frame = ttk.Frame(self.dialog)
         button_frame.grid(row=4, column=0, columnspan=2, pady=10)
 
-        ttk.Button(button_frame, text="OK", command=self.ok).pack(side=tk.LEFT, padx=5)
-        ttk.Button(button_frame, text="Cancel", command=self.cancel).pack(
-            side=tk.LEFT, padx=5
-        )
+        ttk.Button(button_frame, text="OK", command=self.ok).pack(side=tk.LEFT,
+                                                                  padx=5)
+        ttk.Button(button_frame, text="Cancel",
+                   command=self.cancel).pack(side=tk.LEFT, padx=5)
 
         self.result = None
 
@@ -68,9 +68,11 @@ class EditResourceDialog:
             values = {}
             for resource in ["Carbon", "Food", "Nova", "Ore"]:
                 try:
-                    value = float(self.entries[resource].get().replace(",", ""))
+                    value = float(self.entries[resource].get().replace(
+                        ",", ""))
                     if value < 0 or value > 1000000:  # Reasonable limit
-                        raise ValueError(f"{resource} must be between 0 and 1,000,000")
+                        raise ValueError(
+                            f"{resource} must be between 0 and 1,000,000")
                     values[resource] = value
                 except ValueError as exc:
                     raise ValueError(
@@ -127,12 +129,13 @@ class SaveGameGUI:  # pylint: disable=too-many-instance-attributes
         self.file_label.grid(row=0, column=0, padx=5)
 
         self.file_path = tk.StringVar()
-        self.file_entry = ttk.Entry(self.file_frame, textvariable=self.file_path)
+        self.file_entry = ttk.Entry(self.file_frame,
+                                    textvariable=self.file_path)
         self.file_entry.grid(row=0, column=1, padx=5, sticky=(tk.W, tk.E))
 
-        self.browse_button = ttk.Button(
-            self.file_frame, text="Browse", command=self.browse_file
-        )
+        self.browse_button = ttk.Button(self.file_frame,
+                                        text="Browse",
+                                        command=self.browse_file)
         self.browse_button.grid(row=0, column=2, padx=5)
 
         # Button frame
@@ -140,9 +143,9 @@ class SaveGameGUI:  # pylint: disable=too-many-instance-attributes
         self.button_frame.grid(row=1, column=0, pady=10)
 
         # Load and Save buttons
-        self.load_button = ttk.Button(
-            self.button_frame, text="Load Save File", command=self.load_save
-        )
+        self.load_button = ttk.Button(self.button_frame,
+                                      text="Load Save File",
+                                      command=self.load_save)
         self.load_button.grid(row=0, column=0, padx=5)
 
         self.edit_button = ttk.Button(
@@ -163,7 +166,10 @@ class SaveGameGUI:  # pylint: disable=too-many-instance-attributes
 
         # Players treeview
         self.tree_frame = ttk.Frame(self.main_frame)
-        self.tree_frame.grid(row=2, column=0, sticky=(tk.W, tk.E, tk.N, tk.S), pady=5)
+        self.tree_frame.grid(row=2,
+                             column=0,
+                             sticky=(tk.W, tk.E, tk.N, tk.S),
+                             pady=5)
         self.tree_frame.columnconfigure(0, weight=1)
         self.tree_frame.rowconfigure(0, weight=1)
 
@@ -177,16 +183,15 @@ class SaveGameGUI:  # pylint: disable=too-many-instance-attributes
 
         # Configure column headings and widths
         self.tree.heading("Player", text="Player Name")
-        self.tree.column(
-            "Player", width=200, minwidth=150, anchor="w"
-        )  # Left-align player names
+        self.tree.column("Player", width=200, minwidth=150,
+                         anchor="w")  # Left-align player names
 
         # Set fixed widths for resource columns
         for col in ("Carbon", "Food", "Nova", "Ore"):
             self.tree.heading(col, text=col)
             self.tree.column(
-                col, width=90, minwidth=90, stretch=False, anchor="e"
-            )  # Right-align numbers with fixed width
+                col, width=90, minwidth=90, stretch=False,
+                anchor="e")  # Right-align numbers with fixed width
 
         # Make the window resizable
         root.resizable(True, True)
@@ -196,9 +201,9 @@ class SaveGameGUI:  # pylint: disable=too-many-instance-attributes
         self.tree_frame.rowconfigure(0, weight=1)
 
         # Add scrollbar
-        self.scrollbar = ttk.Scrollbar(
-            self.tree_frame, orient=tk.VERTICAL, command=self.tree.yview
-        )
+        self.scrollbar = ttk.Scrollbar(self.tree_frame,
+                                       orient=tk.VERTICAL,
+                                       command=self.tree.yview)
         self.tree.configure(yscrollcommand=self.scrollbar.set)
 
         self.tree.grid(row=0, column=0, sticky=(tk.W, tk.E, tk.N, tk.S))
@@ -206,9 +211,9 @@ class SaveGameGUI:  # pylint: disable=too-many-instance-attributes
 
         # Status bar
         self.status_var = tk.StringVar()
-        self.status_bar = ttk.Label(
-            self.main_frame, textvariable=self.status_var, relief=tk.SUNKEN
-        )
+        self.status_bar = ttk.Label(self.main_frame,
+                                    textvariable=self.status_var,
+                                    relief=tk.SUNKEN)
         self.status_bar.grid(row=3, column=0, sticky=(tk.W, tk.E), pady=5)
 
         self.status_var.set("Ready")
@@ -248,7 +253,8 @@ class SaveGameGUI:  # pylint: disable=too-many-instance-attributes
                 # Resources in player object are [wood, food, nova, ore]
                 # But display them as [food, wood, nova, ore]
                 values = [
-                    f"{player.name} (Player {player.index})",  # Player name column
+                    # Player name column
+                    f"{player.name} (Player {player.index})",
                     f"{player.resources[0]:,.0f}",  # Carbon (index 0)
                     f"{player.resources[1]:,.0f}",  # Food (index 1)
                     f"{player.resources[2]:,.0f}",  # Nova
@@ -265,14 +271,16 @@ class SaveGameGUI:  # pylint: disable=too-many-instance-attributes
             )
 
         except (OSError, RuntimeError, ValueError, TK_ERROR) as e:
-            messagebox.showerror("Error", f"Failed to load save file: {str(e)}")
+            messagebox.showerror("Error",
+                                 f"Failed to load save file: {str(e)}")
             self.status_var.set("Error loading file")
 
     def edit_resources(self):
         """Edit resources for selected player"""
         selection = self.tree.selection()
         if not selection:
-            messagebox.showwarning("No Selection", "Please select a player to edit")
+            messagebox.showwarning("No Selection",
+                                   "Please select a player to edit")
             return
 
         # Get selected player index

--- a/swgb_save_gui.py
+++ b/swgb_save_gui.py
@@ -1,5 +1,7 @@
 """Tkinter UI for inspecting and editing SWGB save resources."""
 
+from __future__ import absolute_import, division
+
 import os
 import shutil
 import tkinter as tk

--- a/tests/test_swgb_save.py
+++ b/tests/test_swgb_save.py
@@ -583,3 +583,78 @@ def test_running_swgb_save_as_main_executes_entrypoint(
     output = capsys.readouterr().out
     assert "Save File:" in output  # nosec B101
     assert "Player One" in output  # nosec B101
+
+
+def test_name_from_direct_scan_consumes_full_name_window() -> None:
+    """A maximal-length name keeps the direct scan looping until the byte cap."""
+    save = swgb_save.SaveGame("dummy.ga2")
+    save.data = b"A" * 40
+
+    # The scan must stop at offset + MAX_NAME_BYTES via the loop condition,
+    # exercising the ``name_end < upper_bound`` exit (no break taken).
+    assert save._name_from_direct_scan(0, 40) == "A" * 32  # nosec B101
+
+
+def test_find_player_entries_loop_exits_on_buffer_boundary() -> None:
+    """The scan loop terminates via its window guard, not a missing pattern."""
+    payload = (
+        swgb_save.PLAYER_PATTERN
+        + struct.pack("<ffff", 10.0, 20.0, 30.0, 40.0)
+        + b"\x00" * 11
+    )
+    # ``len - 32`` is 1, so after matching at offset 0 the next ``pos`` (1)
+    # fails ``pos < len(self.data) - 32`` and the while loop exits by condition.
+    assert len(payload) == 33  # nosec B101
+
+    save = swgb_save.SaveGame("dummy.ga2")
+    save.data = payload
+
+    save._find_player_entries()
+
+    assert [(player.name, player.resources) for player in save.players] == [  # nosec B101
+        ("Player 1", [20.0, 10.0, 30.0, 40.0])
+    ]
+
+
+def test_match_player_skips_already_updated_and_unknown_names() -> None:
+    """The matcher walks every player when none qualifies for an update."""
+    save = swgb_save.SaveGame("dummy.ga2")
+    save.players = [
+        swgb_save.Player("Alice", 1, [1.0, 2.0, 3.0, 4.0]),
+        swgb_save.Player("Bob", 2, [1.0, 2.0, 3.0, 4.0]),
+    ]
+
+    # "Bob" matches by name but is already updated, so the loop continues past
+    # it; "Zed" matches nobody. Both paths take the for-loop continuation edge.
+    assert save._match_player("Bob", {"Bob"}) is None  # nosec B101
+    assert save._match_player("Zed", set()) is None  # nosec B101
+
+
+def test_rewrite_player_resources_loop_exits_on_buffer_boundary() -> None:
+    """Rewriting also terminates through the window guard, not a sentinel."""
+    payload = (
+        swgb_save.PLAYER_PATTERN
+        + struct.pack("<ffff", 10.0, 20.0, 30.0, 40.0)
+        + b"\x00" * 11
+    )
+    assert len(payload) == 33  # nosec B101
+
+    save = swgb_save.SaveGame("dummy.ga2")
+    save.data = payload
+    save.players = [swgb_save.Player("Player 1", 1, [1.0, 2.0, 3.0, 4.0])]
+
+    assert save._rewrite_player_resources(bytearray(payload)) == set()  # nosec B101
+
+
+def test_create_backup_if_missing_preserves_existing_backup(tmp_path: Path) -> None:
+    """An existing backup is left untouched instead of being overwritten."""
+    save_file = tmp_path / "save.ga2"
+    save_file.write_bytes(b"new-data")
+    backup_file = tmp_path / "save.ga2.backup"
+    backup_file.write_bytes(b"original-backup")
+
+    swgb_save.SaveGame._create_backup_if_missing(str(save_file))
+
+    # The ``not os.path.exists`` guard is False, so copy2 is skipped and the
+    # pre-existing backup content survives unchanged.
+    assert backup_file.read_bytes() == b"original-backup"  # nosec B101

--- a/tests/test_swgb_save.py
+++ b/tests/test_swgb_save.py
@@ -1,13 +1,10 @@
 from __future__ import absolute_import, division
 
-# mypy: disable-error-code=assignment
-# pylint: disable=protected-access
-
+import builtins
 import runpy
 import struct
 import sys
 import zlib
-import builtins
 from pathlib import Path
 from typing import List, Tuple
 
@@ -15,19 +12,16 @@ import pytest
 
 import swgb_save
 
+# mypy: disable-error-code=assignment
+# pylint: disable=protected-access
 
-def _player_blob(name: str, values: Tuple[float, float, float, float]) -> bytes:
+
+def _player_blob(name: str, values: Tuple[float, float, float,
+                                          float]) -> bytes:
     pattern = bytes.fromhex("16db00000021")
-    return (
-        b"\x00" * 8
-        + b"\x09\x00"
-        + name.encode("ascii")
-        + b"\x00"
-        + b"\x00" * 8
-        + pattern
-        + struct.pack("<ffff", *values)
-        + b"\x00" * 16
-    )
+    return (b"\x00" * 8 + b"\x09\x00" + name.encode("ascii") + b"\x00" +
+            b"\x00" * 8 + pattern + struct.pack("<ffff", *values) +
+            b"\x00" * 16)
 
 
 def _raw_deflate(payload: bytes) -> bytes:
@@ -71,8 +65,7 @@ def test_read_raises_when_decompression_never_succeeds(
 
 
 def test_read_parses_player_resources_and_tracks_successful_wbits(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     path = tmp_path / "player.ga2"
     path.write_bytes(b"compressed-placeholder")
     payload = _player_blob("Player One", (10.0, 20.0, 30.0, 40.0))
@@ -91,14 +84,14 @@ def test_read_parses_player_resources_and_tracks_successful_wbits(
 
     assert calls == [zlib.MAX_WBITS, 15, -15]  # nosec B101
     assert save.wbits == -15  # nosec B101
-    assert [
-        (player.name, player.index, player.resources) for player in save.players
-    ] == [  # nosec B101
-        ("Player One", 1, [20.0, 10.0, 30.0, 40.0])
-    ]
+    assert [(player.name, player.index, player.resources)
+            for player in save.players] == [  # nosec B101
+                ("Player One", 1, [20.0, 10.0, 30.0, 40.0])
+            ]
 
 
-def test_save_updates_resources_creates_backup_and_writes_compressed_bytes(tmp_path: Path) -> None:
+def test_save_updates_resources_creates_backup_and_writes_compressed_bytes(
+    tmp_path: Path, ) -> None:
     path = tmp_path / "edit.ga2"
     original_payload = _player_blob("Player One", (1.0, 2.0, 3.0, 4.0))
     original_compressed = _raw_deflate(original_payload)
@@ -106,7 +99,9 @@ def test_save_updates_resources_creates_backup_and_writes_compressed_bytes(tmp_p
 
     save = swgb_save.SaveGame(str(path))
     save.data = original_payload
-    save.players = [swgb_save.Player("Player One", 1, [11.0, 22.0, 33.0, 44.0])]
+    save.players = [
+        swgb_save.Player("Player One", 1, [11.0, 22.0, 33.0, 44.0])
+    ]
 
     save.save()
 
@@ -115,14 +110,17 @@ def test_save_updates_resources_creates_backup_and_writes_compressed_bytes(tmp_p
     restored = zlib.decompress(path.read_bytes(), -15)
     pattern_pos = restored.find(bytes.fromhex("16db00000021"))
     resource_start = pattern_pos + 6
-    written = struct.unpack("<ffff", restored[resource_start : resource_start + 16])
+    written = struct.unpack("<ffff",
+                            restored[resource_start:resource_start + 16])
     assert written == pytest.approx((11.0, 22.0, 33.0, 44.0))  # nosec B101
 
 
 def test_print_info_lists_players(capsys: pytest.CaptureFixture[str]) -> None:
     save = swgb_save.SaveGame("dummy.ga2")
     save.data = b"x" * 12
-    save.players = [swgb_save.Player("Player One", 1, [100.0, 200.0, 300.0, 400.0])]
+    save.players = [
+        swgb_save.Player("Player One", 1, [100.0, 200.0, 300.0, 400.0])
+    ]
 
     save.print_info()
 
@@ -155,11 +153,12 @@ def test_main_shows_usage_without_path(
 
 
 def test_main_reads_and_prints_when_given_a_path(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
     events: List[Tuple[str, str]] = []
 
     class FakeSaveGame:
+
         def __init__(self, filename: str):
             events.append(("init", filename))
 
@@ -174,16 +173,21 @@ def test_main_reads_and_prints_when_given_a_path(
 
     swgb_save.main()
 
-    assert events == [("init", "example.ga2"), ("read", ""), ("print_info", "")]  # nosec B101
+    assert events == [
+        ("init", "example.ga2"),
+        ("read", ""),
+        ("print_info", ""),
+    ]  # nosec B101
     assert capsys.readouterr().out == ""  # nosec B101
 
 
 def test_read_reports_when_no_players_are_found(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
     path = tmp_path / "empty.ga2"
     path.write_bytes(b"compressed-placeholder")
-    monkeypatch.setattr(swgb_save.zlib, "decompress", lambda _data, _wbits: b"\x00" * 80)
+    monkeypatch.setattr(swgb_save.zlib, "decompress",
+                        lambda _data, _wbits: b"\x00" * 80)
 
     save = swgb_save.SaveGame(str(path))
     save.read()
@@ -194,27 +198,20 @@ def test_read_reports_when_no_players_are_found(
 
 
 def test_find_player_entries_handles_marker_and_direct_name_fallbacks(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
+    capsys: pytest.CaptureFixture[str], ) -> None:
     pattern = bytes.fromhex("16db00000021")
-    payload = (
-        b"\x00" * 12
-        + b"\x09\x00\xff\x00"
-        + b"@@@"
-        + b"Han Solo\x00"
-        + b"\x00" * 8
-        + pattern
-        + struct.pack("<ffff", 10.0, 20.0, 30.0, 40.0)
-        + b"\x00" * 32
-    )
+    payload = (b"\x00" * 12 + b"\x09\x00\xff\x00" + b"@@@" + b"Han Solo\x00" +
+               b"\x00" * 8 + pattern +
+               struct.pack("<ffff", 10.0, 20.0, 30.0, 40.0) + b"\x00" * 32)
     save = swgb_save.SaveGame("dummy.ga2")
     save.data = payload
 
     entries = save._find_player_entries()
 
-    assert [(player.name, player.resources) for player in save.players] == [  # nosec B101
-        ("Han Solo", [20.0, 10.0, 30.0, 40.0])
-    ]
+    assert [(player.name, player.resources)
+            for player in save.players] == [  # nosec B101
+                ("Han Solo", [20.0, 10.0, 30.0, 40.0])
+            ]
     assert len(entries) == 1  # nosec B101
     assert entries[0][:3] == (36, "Han Solo", 1)  # nosec B101
     assert len(entries[0][3]) == 16  # nosec B101
@@ -224,28 +221,24 @@ def test_find_player_entries_handles_marker_and_direct_name_fallbacks(
 
 def test_find_player_entries_handles_direct_name_decode_errors() -> None:
     pattern = bytes.fromhex("16db00000021")
-    payload = (
-        b"\x00" * 12
-        + (b"\xe9" * 4)
-        + b"\x00"
-        + b"\x00" * 8
-        + pattern
-        + struct.pack("<ffff", 1.0, 2.0, 3.0, 4.0)
-        + b"\x00" * 32
-    )
+    payload = (b"\x00" * 12 + (b"\xe9" * 4) + b"\x00" + b"\x00" * 8 + pattern +
+               struct.pack("<ffff", 1.0, 2.0, 3.0, 4.0) + b"\x00" * 32)
     save = swgb_save.SaveGame("dummy.ga2")
     save.data = payload
 
     save._find_player_entries()
 
-    assert save.players == [swgb_save.Player("Player 1", 1, [2.0, 1.0, 3.0, 4.0])]  # nosec B101
+    assert save.players == [
+        swgb_save.Player("Player 1", 1, [2.0, 1.0, 3.0, 4.0])
+    ]  # nosec B101
 
 
 def test_decode_candidate_name_rejects_non_alnum_characters() -> None:
     save = swgb_save.SaveGame("dummy.ga2")
     save.data = b"Han!"
 
-    assert save._decode_candidate_name(0, 4, min_length=3) is None  # nosec B101
+    assert save._decode_candidate_name(0, 4,
+                                       min_length=3) is None  # nosec B101
 
 
 def test_name_from_marker_returns_none_when_offset_exceeds_data() -> None:
@@ -264,12 +257,18 @@ def test_read_resource_values_returns_none_without_loaded_data() -> None:
 def test_build_entry_uses_empty_payload_without_loaded_data() -> None:
     save = swgb_save.SaveGame("dummy.ga2")
 
-    assert save._build_entry(12, "Player One", 1) == (12, "Player One", 1, b"")  # nosec B101
+    assert save._build_entry(12, "Player One", 1) == (
+        12,
+        "Player One",
+        1,
+        b"",
+    )  # nosec B101
 
 
 def test_find_player_entries_skips_out_of_range_resource_sequences() -> None:
     pattern = bytes.fromhex("16db00000021")
-    payload = pattern + struct.pack("<ffff", 1.0, 2.0, 3.0, 100001.0) + b"\x00" * 48
+    payload = pattern + struct.pack("<ffff", 1.0, 2.0, 3.0,
+                                    100001.0) + b"\x00" * 48
     save = swgb_save.SaveGame("dummy.ga2")
     save.data = payload
 
@@ -279,8 +278,7 @@ def test_find_player_entries_skips_out_of_range_resource_sequences() -> None:
 
 
 def test_find_player_entries_handles_unpack_errors(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+    monkeypatch: pytest.MonkeyPatch, ) -> None:
     pattern = bytes.fromhex("16db00000021")
     payload = pattern + struct.pack("<ffff", 1.0, 2.0, 3.0, 4.0) + b"\x00" * 48
     save = swgb_save.SaveGame("dummy.ga2")
@@ -302,13 +300,13 @@ def test_find_player_entries_handles_unpack_errors(
 
 
 def test_find_player_entries_logs_processing_errors(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
+    capsys: pytest.CaptureFixture[str], ) -> None:
     payload = _player_blob("Player One", (10.0, 20.0, 30.0, 40.0))
     save = swgb_save.SaveGame("dummy.ga2")
     save.data = payload
 
     class BrokenPlayers(list):
+
         def append(self, _item):
             raise RuntimeError("boom")
 
@@ -326,17 +324,11 @@ def test_find_player_entries_returns_empty_without_loaded_data() -> None:
 
 
 def test_save_updates_via_direct_name_match_and_warns_for_missing_players(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+        tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     path = tmp_path / "direct.ga2"
-    payload = (
-        b"\x00" * 16
-        + b"Han Solo\x00"
-        + b"\x00" * 8
-        + bytes.fromhex("16db00000021")
-        + struct.pack("<ffff", 1.0, 2.0, 3.0, 4.0)
-        + b"\x00" * 32
-    )
+    payload = (b"\x00" * 16 + b"Han Solo\x00" + b"\x00" * 8 +
+               bytes.fromhex("16db00000021") +
+               struct.pack("<ffff", 1.0, 2.0, 3.0, 4.0) + b"\x00" * 32)
     path.write_bytes(_raw_deflate(payload))
 
     save = swgb_save.SaveGame(str(path))
@@ -353,13 +345,13 @@ def test_save_updates_via_direct_name_match_and_warns_for_missing_players(
     resource_start = pattern_pos + 6
     assert struct.unpack(
         "<ffff",
-        restored[resource_start : resource_start + 16],
+        restored[resource_start:resource_start + 16],
     ) == pytest.approx(  # nosec B101
-        (11.0, 22.0, 33.0, 44.0)
-    )
+        (11.0, 22.0, 33.0, 44.0))
     output = capsys.readouterr().out
     assert "Found potential name (direct): 'Han Solo'" in output  # nosec B101
-    assert "Warning: Could not update resources for players: {'Leia'}" in output  # nosec B101
+    # nosec B101
+    assert "Warning: Could not update resources for players: {'Leia'}" in output
 
 
 def test_save_requires_loaded_data(tmp_path: Path) -> None:
@@ -370,15 +362,17 @@ def test_save_requires_loaded_data(tmp_path: Path) -> None:
 
 
 def test_save_continues_after_name_processing_errors(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
     path = tmp_path / "broken-save.ga2"
     payload = _player_blob("Player One", (1.0, 2.0, 3.0, 4.0))
     path.write_bytes(_raw_deflate(payload))
 
     save = swgb_save.SaveGame(str(path))
     save.data = payload
-    save.players = [swgb_save.Player("Player One", 1, [11.0, 22.0, 33.0, 44.0])]
+    save.players = [
+        swgb_save.Player("Player One", 1, [11.0, 22.0, 33.0, 44.0])
+    ]
 
     monkeypatch.setattr(
         swgb_save.struct,
@@ -397,25 +391,19 @@ def test_update_matching_player_requires_loaded_data() -> None:
     save.players = [swgb_save.Player("Han Solo", 1, [11.0, 22.0, 33.0, 44.0])]
 
     save._find_name_before_pattern = (  # type: ignore[method-assign]
-        lambda *args, **kwargs: "Han Solo"
-    )
+        lambda *args, **kwargs: "Han Solo")
 
     with pytest.raises(ValueError, match="No save data loaded"):
         save._update_matching_player(0, bytearray(), set())
 
 
 def test_save_logs_mismatched_written_values_for_direct_name_updates(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
     path = tmp_path / "mismatch.ga2"
-    payload = (
-        b"\x00" * 16
-        + b"Han Solo\x00"
-        + b"\x00" * 8
-        + bytes.fromhex("16db00000021")
-        + struct.pack("<ffff", 1.0, 2.0, 3.0, 4.0)
-        + b"\x00" * 32
-    )
+    payload = (b"\x00" * 16 + b"Han Solo\x00" + b"\x00" * 8 +
+               bytes.fromhex("16db00000021") +
+               struct.pack("<ffff", 1.0, 2.0, 3.0, 4.0) + b"\x00" * 32)
     path.write_bytes(_raw_deflate(payload))
 
     save = swgb_save.SaveGame(str(path))
@@ -430,21 +418,16 @@ def test_save_logs_mismatched_written_values_for_direct_name_updates(
 
     save.save()
 
-    assert "WARNING: Resource value mismatch!" in capsys.readouterr().out  # nosec B101
+    assert "WARNING: Resource value mismatch!" in capsys.readouterr(
+    ).out  # nosec B101
 
 
 def test_save_handles_invalid_direct_name_characters(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+        tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     path = tmp_path / "invalid-direct.ga2"
-    payload = (
-        b"\x00" * 16
-        + b"Han!\x00"
-        + b"\x00" * 8
-        + bytes.fromhex("16db00000021")
-        + struct.pack("<ffff", 1.0, 2.0, 3.0, 4.0)
-        + b"\x00" * 32
-    )
+    payload = (b"\x00" * 16 + b"Han!\x00" + b"\x00" * 8 +
+               bytes.fromhex("16db00000021") +
+               struct.pack("<ffff", 1.0, 2.0, 3.0, 4.0) + b"\x00" * 32)
     path.write_bytes(_raw_deflate(payload))
 
     save = swgb_save.SaveGame(str(path))
@@ -453,24 +436,16 @@ def test_save_handles_invalid_direct_name_characters(
 
     save.save()
 
-    assert (
-        "Warning: Could not update resources for players: {'Han'}"
-        in capsys.readouterr().out
-    )  # nosec B101
+    assert ("Warning: Could not update resources for players: {'Han'}"
+            in capsys.readouterr().out)  # nosec B101
 
 
 def test_save_skips_direct_name_candidates_with_invalid_characters(
-    tmp_path: Path
-) -> None:
+    tmp_path: Path, ) -> None:
     path = tmp_path / "direct-invalid.ga2"
-    payload = (
-        b"\x00" * 16
-        + b"Han!\x00"
-        + b"\x00" * 8
-        + bytes.fromhex("16db00000021")
-        + struct.pack("<ffff", 1.0, 2.0, 3.0, 4.0)
-        + b"\x00" * 32
-    )
+    payload = (b"\x00" * 16 + b"Han!\x00" + b"\x00" * 8 +
+               bytes.fromhex("16db00000021") +
+               struct.pack("<ffff", 1.0, 2.0, 3.0, 4.0) + b"\x00" * 32)
     path.write_bytes(_raw_deflate(payload))
 
     save = swgb_save.SaveGame(str(path))
@@ -481,15 +456,17 @@ def test_save_skips_direct_name_candidates_with_invalid_characters(
 
 
 def test_save_logs_outer_processing_warning_when_search_setup_fails(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
     path = tmp_path / "outer-warning.ga2"
     payload = _player_blob("Player One", (1.0, 2.0, 3.0, 4.0))
     path.write_bytes(_raw_deflate(payload))
 
     save = swgb_save.SaveGame(str(path))
     save.data = payload
-    save.players = [swgb_save.Player("Player One", 1, [11.0, 22.0, 33.0, 44.0])]
+    save.players = [
+        swgb_save.Player("Player One", 1, [11.0, 22.0, 33.0, 44.0])
+    ]
     real_max = builtins.max
     call_count = {"count": 0}
 
@@ -504,12 +481,13 @@ def test_save_logs_outer_processing_warning_when_search_setup_fails(
     save.save()
     assert builtins.max(1, 2) == 2  # nosec B101
 
-    assert "Warning: Error processing pattern" in capsys.readouterr().out  # nosec B101
+    assert "Warning: Error processing pattern" in capsys.readouterr(
+    ).out  # nosec B101
 
 
 def test_save_raises_when_compression_fails(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
     path = tmp_path / "compress-fail.ga2"
     payload = _player_blob("Player One", (1.0, 2.0, 3.0, 4.0))
     path.write_bytes(_raw_deflate(payload))
@@ -527,7 +505,8 @@ def test_save_raises_when_compression_fails(
     with pytest.raises(RuntimeError, match="compress boom"):
         save.save()
 
-    assert "Error saving file: compress boom" in capsys.readouterr().out  # nosec B101
+    assert "Error saving file: compress boom" in capsys.readouterr(
+    ).out  # nosec B101
 
 
 def test_rewrite_player_resources_requires_loaded_data() -> None:
@@ -545,9 +524,11 @@ def test_compress_and_write_requires_loaded_data(tmp_path: Path) -> None:
 
 
 def test_main_reports_errors_when_read_fails(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
+
     class FakeSaveGame:
+
         def __init__(self, _filename: str):
             # Test double: the constructor intentionally performs no I/O.
             pass
@@ -572,10 +553,11 @@ def test_main_reports_errors_when_read_fails(
 
 
 def test_running_swgb_save_as_main_executes_entrypoint(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
     save_path = tmp_path / "script-run.ga2"
-    save_path.write_bytes(_raw_deflate(_player_blob("Player One", (1.0, 2.0, 3.0, 4.0))))
+    save_path.write_bytes(
+        _raw_deflate(_player_blob("Player One", (1.0, 2.0, 3.0, 4.0))))
     monkeypatch.setattr(sys, "argv", ["swgb_save.py", str(save_path)])
 
     runpy.run_path(str(Path(swgb_save.__file__)), run_name="__main__")
@@ -597,11 +579,8 @@ def test_name_from_direct_scan_consumes_full_name_window() -> None:
 
 def test_find_player_entries_loop_exits_on_buffer_boundary() -> None:
     """The scan loop terminates via its window guard, not a missing pattern."""
-    payload = (
-        swgb_save.PLAYER_PATTERN
-        + struct.pack("<ffff", 10.0, 20.0, 30.0, 40.0)
-        + b"\x00" * 11
-    )
+    payload = (swgb_save.PLAYER_PATTERN +
+               struct.pack("<ffff", 10.0, 20.0, 30.0, 40.0) + b"\x00" * 11)
     # ``len - 32`` is 1, so after matching at offset 0 the next ``pos`` (1)
     # fails ``pos < len(self.data) - 32`` and the while loop exits by condition.
     assert len(payload) == 33  # nosec B101
@@ -611,9 +590,10 @@ def test_find_player_entries_loop_exits_on_buffer_boundary() -> None:
 
     save._find_player_entries()
 
-    assert [(player.name, player.resources) for player in save.players] == [  # nosec B101
-        ("Player 1", [20.0, 10.0, 30.0, 40.0])
-    ]
+    assert [(player.name, player.resources)
+            for player in save.players] == [  # nosec B101
+                ("Player 1", [20.0, 10.0, 30.0, 40.0])
+            ]
 
 
 def test_match_player_skips_already_updated_and_unknown_names() -> None:
@@ -632,21 +612,20 @@ def test_match_player_skips_already_updated_and_unknown_names() -> None:
 
 def test_rewrite_player_resources_loop_exits_on_buffer_boundary() -> None:
     """Rewriting also terminates through the window guard, not a sentinel."""
-    payload = (
-        swgb_save.PLAYER_PATTERN
-        + struct.pack("<ffff", 10.0, 20.0, 30.0, 40.0)
-        + b"\x00" * 11
-    )
+    payload = (swgb_save.PLAYER_PATTERN +
+               struct.pack("<ffff", 10.0, 20.0, 30.0, 40.0) + b"\x00" * 11)
     assert len(payload) == 33  # nosec B101
 
     save = swgb_save.SaveGame("dummy.ga2")
     save.data = payload
     save.players = [swgb_save.Player("Player 1", 1, [1.0, 2.0, 3.0, 4.0])]
 
-    assert save._rewrite_player_resources(bytearray(payload)) == set()  # nosec B101
+    assert save._rewrite_player_resources(
+        bytearray(payload)) == set()  # nosec B101
 
 
-def test_create_backup_if_missing_preserves_existing_backup(tmp_path: Path) -> None:
+def test_create_backup_if_missing_preserves_existing_backup(
+        tmp_path: Path) -> None:
     """An existing backup is left untouched instead of being overwritten."""
     save_file = tmp_path / "save.ga2"
     save_file.write_bytes(b"new-data")

--- a/tests/test_swgb_save_gui.py
+++ b/tests/test_swgb_save_gui.py
@@ -15,6 +15,7 @@ import pytest
 
 
 class FakeStringVar:
+
     def __init__(self, value: str = ""):
         self.value = value
 
@@ -26,12 +27,14 @@ class FakeStringVar:
 
 
 class FakeWidget:
+
     def __init__(self, *_args: object, **kwargs: object) -> None:
         self.state = kwargs.get("state")
         self.textvariable = kwargs.get("textvariable")
         self.command = kwargs.get("command")
         self.destroyed = False
-        self._layout_calls: Dict[str, Tuple[Tuple[object, ...], Dict[str, object]]] = {}
+        self._layout_calls: Dict[str, Tuple[Tuple[object, ...],
+                                            Dict[str, object]]] = {}
 
     def grid(self, *args, **kwargs):
         self._layout_calls["grid"] = (args, kwargs)
@@ -61,6 +64,7 @@ class FakeWidget:
 
 
 class FakeRoot(FakeWidget):
+
     def __init__(self, *args: object, **kwargs: object) -> None:
         super().__init__(*args, **kwargs)
         self._window_state: Dict[str, object] = {}
@@ -108,6 +112,7 @@ class FakeRoot(FakeWidget):
 
 
 class FakeTreeview(FakeWidget):
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.rows = {}
@@ -154,7 +159,7 @@ class FakeTreeview(FakeWidget):
         return self.selected
 
     def selection_set(self, item_id):
-        self.selected = (item_id,)
+        self.selected = (item_id, )
 
 
 def test_fake_widget_helpers_are_noops() -> None:
@@ -166,27 +171,41 @@ def test_fake_widget_helpers_are_noops() -> None:
 
 
 def install_fake_tk(monkeypatch: pytest.MonkeyPatch):
-    message_calls: Dict[str, List[Tuple[str, str]]] = {"error": [], "warning": [], "info": []}
+    message_calls: Dict[str, List[Tuple[str, str]]] = {
+        "error": [],
+        "warning": [],
+        "info": [],
+    }
     dialog_state = {"filename": ""}
 
     ttk_module = types.ModuleType("tkinter.ttk")
     for widget_name, widget_value in {
-        "Label": FakeWidget,
-        "Entry": FakeWidget,
-        "Frame": FakeWidget,
-        "Button": FakeWidget,
-        "Treeview": FakeTreeview,
-        "Scrollbar": FakeWidget,
+            "Label": FakeWidget,
+            "Entry": FakeWidget,
+            "Frame": FakeWidget,
+            "Button": FakeWidget,
+            "Treeview": FakeTreeview,
+            "Scrollbar": FakeWidget,
     }.items():
         setattr(ttk_module, widget_name, widget_value)
 
     filedialog_module = types.ModuleType("tkinter.filedialog")
-    setattr(filedialog_module, "askopenfilename", lambda **_kwargs: dialog_state["filename"])
+    setattr(filedialog_module, "askopenfilename",
+            lambda **_kwargs: dialog_state["filename"])
 
     messagebox_module = types.ModuleType("tkinter.messagebox")
-    setattr(messagebox_module, "showerror", lambda *args: message_calls["error"].append(args))
-    setattr(messagebox_module, "showwarning", lambda *args: message_calls["warning"].append(args))
-    setattr(messagebox_module, "showinfo", lambda *args: message_calls["info"].append(args))
+    setattr(
+        messagebox_module,
+        "showerror",
+        lambda *args: message_calls["error"].append(args),
+    )
+    setattr(
+        messagebox_module,
+        "showwarning",
+        lambda *args: message_calls["warning"].append(args),
+    )
+    setattr(messagebox_module, "showinfo",
+            lambda *args: message_calls["info"].append(args))
 
     tk_module = types.ModuleType("tkinter")
     tk_members: Dict[str, object] = {
@@ -219,10 +238,12 @@ def install_fake_tk(monkeypatch: pytest.MonkeyPatch):
     return module, dialog_state, message_calls
 
 
-def test_edit_resource_dialog_accepts_valid_values(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_edit_resource_dialog_accepts_valid_values(
+    monkeypatch: pytest.MonkeyPatch, ) -> None:
     gui, _dialog_state, message_calls = install_fake_tk(monkeypatch)
 
-    dialog = gui.EditResourceDialog(gui.tk.Tk(), "Player One", [1.0, 2.0, 3.0, 4.0])
+    dialog = gui.EditResourceDialog(gui.tk.Tk(), "Player One",
+                                    [1.0, 2.0, 3.0, 4.0])
     dialog.entries["Carbon"].set("10")
     dialog.entries["Food"].set("20")
     dialog.entries["Nova"].set("30")
@@ -235,10 +256,12 @@ def test_edit_resource_dialog_accepts_valid_values(monkeypatch: pytest.MonkeyPat
     assert not message_calls["error"]  # nosec B101
 
 
-def test_edit_resource_dialog_rejects_invalid_values(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_edit_resource_dialog_rejects_invalid_values(
+    monkeypatch: pytest.MonkeyPatch, ) -> None:
     gui, _dialog_state, message_calls = install_fake_tk(monkeypatch)
 
-    dialog = gui.EditResourceDialog(gui.tk.Tk(), "Player One", [1.0, 2.0, 3.0, 4.0])
+    dialog = gui.EditResourceDialog(gui.tk.Tk(), "Player One",
+                                    [1.0, 2.0, 3.0, 4.0])
     dialog.entries["Carbon"].set("-1")
 
     dialog.ok()
@@ -248,12 +271,15 @@ def test_edit_resource_dialog_rejects_invalid_values(monkeypatch: pytest.MonkeyP
     assert message_calls["error"]  # nosec B101
 
 
-def test_edit_resource_dialog_handles_unexpected_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_edit_resource_dialog_handles_unexpected_errors(
+    monkeypatch: pytest.MonkeyPatch, ) -> None:
     gui, _dialog_state, message_calls = install_fake_tk(monkeypatch)
 
-    dialog = gui.EditResourceDialog(gui.tk.Tk(), "Player One", [1.0, 2.0, 3.0, 4.0])
+    dialog = gui.EditResourceDialog(gui.tk.Tk(), "Player One",
+                                    [1.0, 2.0, 3.0, 4.0])
 
     class BrokenVar:  # pylint: disable=too-few-public-methods
+
         @staticmethod
         def get():
             raise RuntimeError("boom")
@@ -264,30 +290,35 @@ def test_edit_resource_dialog_handles_unexpected_errors(monkeypatch: pytest.Monk
 
     assert dialog.result is None  # nosec B101
     assert dialog.dialog.destroyed is False  # nosec B101
-    assert message_calls["error"][-1] == ("Error", "Failed to save changes: boom")  # nosec B101
+    # nosec B101
+    assert message_calls["error"][-1] == ("Error",
+                                          "Failed to save changes: boom")
 
 
-def test_edit_resource_dialog_cancel_closes_dialog(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_edit_resource_dialog_cancel_closes_dialog(
+    monkeypatch: pytest.MonkeyPatch, ) -> None:
     gui, _dialog_state, _message_calls = install_fake_tk(monkeypatch)
 
-    dialog = gui.EditResourceDialog(gui.tk.Tk(), "Player One", [1.0, 2.0, 3.0, 4.0])
+    dialog = gui.EditResourceDialog(gui.tk.Tk(), "Player One",
+                                    [1.0, 2.0, 3.0, 4.0])
     dialog.cancel()
 
     assert dialog.dialog.destroyed is True  # nosec B101
 
 
 def test_save_game_gui_loads_browse_edit_and_save_flows(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     gui, dialog_state, message_calls = install_fake_tk(monkeypatch)
 
     class FakePlayer:  # pylint: disable=too-few-public-methods
+
         def __init__(self, name, index, resources):
             self.name = name
             self.index = index
             self.resources = resources
 
     class FakeSaveGame:
+
         def __init__(self, filename: str):
             self.filename = filename
             self.players = [FakePlayer("Alpha", 1, [10.0, 20.0, 30.0, 40.0])]
@@ -324,13 +355,19 @@ def test_save_game_gui_loads_browse_edit_and_save_flows(
     app.tree.selection_set(tree_items[0])
 
     class FakeDialog:  # pylint: disable=too-few-public-methods
+
         def __init__(self, *_args, **_kwargs):
             self.dialog = object()
             self.result = [100.0, 200.0, 300.0, 400.0]
 
     monkeypatch.setattr(gui, "EditResourceDialog", FakeDialog)
     app.edit_resources()
-    assert app.current_save.players[0].resources == [100.0, 200.0, 300.0, 400.0]  # nosec B101
+    assert app.current_save.players[0].resources == [
+        100.0,
+        200.0,
+        300.0,
+        400.0,
+    ]  # nosec B101
     assert "Updated resources" in app.status_var.get()  # nosec B101
 
     app.save_changes()
@@ -339,8 +376,7 @@ def test_save_game_gui_loads_browse_edit_and_save_flows(
 
 
 def test_save_game_gui_handles_missing_selection_and_save_errors(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     gui, _dialog_state, message_calls = install_fake_tk(monkeypatch)
     root = gui.tk.Tk()
     app = gui.SaveGameGUI(root)
@@ -349,6 +385,7 @@ def test_save_game_gui_handles_missing_selection_and_save_errors(
     assert message_calls["warning"]  # nosec B101
 
     class FailingSave:  # pylint: disable=too-few-public-methods
+
         @staticmethod
         def save(_filename):
             raise RuntimeError("boom")
@@ -371,10 +408,12 @@ def test_load_save_requires_a_path(monkeypatch: pytest.MonkeyPatch) -> None:
     assert message_calls["error"]  # nosec B101
 
 
-def test_load_save_surfaces_read_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_load_save_surfaces_read_errors(monkeypatch: pytest.MonkeyPatch,
+                                        tmp_path: Path) -> None:
     gui, dialog_state, message_calls = install_fake_tk(monkeypatch)
 
     class BrokenSaveGame:  # pylint: disable=too-few-public-methods
+
         def __init__(self, _filename: str):
             self.players: List[object] = []
 
@@ -397,22 +436,29 @@ def test_load_save_surfaces_read_errors(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert app.status_var.get() == "Error loading file"  # nosec B101
 
 
-def test_save_changes_returns_early_when_no_current_save(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_save_changes_returns_early_when_no_current_save(
+    monkeypatch: pytest.MonkeyPatch, ) -> None:
     gui, _dialog_state, message_calls = install_fake_tk(monkeypatch)
     app = gui.SaveGameGUI(gui.tk.Tk())
 
     app.save_changes()
 
-    assert message_calls == {"error": [], "warning": [], "info": []}  # nosec B101
+    assert message_calls == {
+        "error": [],
+        "warning": [],
+        "info": []
+    }  # nosec B101
 
 
-def test_main_builds_gui_and_enters_mainloop(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_main_builds_gui_and_enters_mainloop(
+        monkeypatch: pytest.MonkeyPatch) -> None:
     gui, _dialog_state, _message_calls = install_fake_tk(monkeypatch)
     root = gui.tk.Tk()
     monkeypatch.setattr(gui.tk, "Tk", lambda: root)
     captured = {}
 
     class FakeApp:  # pylint: disable=too-few-public-methods
+
         def __init__(self, passed_root):
             captured["root"] = passed_root
 
@@ -424,7 +470,8 @@ def test_main_builds_gui_and_enters_mainloop(monkeypatch: pytest.MonkeyPatch) ->
     assert root.mainloop_called is True  # nosec B101
 
 
-def test_running_swgb_save_gui_as_main_executes_entrypoint(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_running_swgb_save_gui_as_main_executes_entrypoint(
+    monkeypatch: pytest.MonkeyPatch, ) -> None:
     gui, _dialog_state, _message_calls = install_fake_tk(monkeypatch)
     root = gui.tk.Tk()
     monkeypatch.setattr(gui.tk, "Tk", lambda: root)
@@ -434,7 +481,8 @@ def test_running_swgb_save_gui_as_main_executes_entrypoint(monkeypatch: pytest.M
     assert root.mainloop_called is True  # nosec B101
 
 
-def test_browse_file_keeps_path_when_dialog_is_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_browse_file_keeps_path_when_dialog_is_cancelled(
+    monkeypatch: pytest.MonkeyPatch, ) -> None:
     gui, dialog_state, _message_calls = install_fake_tk(monkeypatch)
     app = gui.SaveGameGUI(gui.tk.Tk())
     app.file_path.set("previous.ga2")
@@ -447,25 +495,30 @@ def test_browse_file_keeps_path_when_dialog_is_cancelled(monkeypatch: pytest.Mon
     assert app.file_path.get() == "previous.ga2"  # nosec B101
 
 
-def test_edit_resources_ignores_cancelled_dialog(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_edit_resources_ignores_cancelled_dialog(
+    monkeypatch: pytest.MonkeyPatch, ) -> None:
     gui, _dialog_state, _message_calls = install_fake_tk(monkeypatch)
 
     class FakePlayer:  # pylint: disable=too-few-public-methods
+
         def __init__(self) -> None:
             self.name = "Alpha"
             self.index = 1
             self.resources = [10.0, 20.0, 30.0, 40.0]
 
     class FakeSave:  # pylint: disable=too-few-public-methods
+
         def __init__(self) -> None:
             self.players = [FakePlayer()]
 
     app = gui.SaveGameGUI(gui.tk.Tk())
     app.current_save = FakeSave()
-    item_id = app.tree.insert("", "end", values=["Alpha (Player 1)", "10", "20", "30", "40"])
+    item_id = app.tree.insert(
+        "", "end", values=["Alpha (Player 1)", "10", "20", "30", "40"])
     app.tree.selection_set(item_id)
 
     class CancelledDialog:  # pylint: disable=too-few-public-methods
+
         def __init__(self, *_args, **_kwargs):
             self.dialog = object()
             self.result = None
@@ -474,16 +527,21 @@ def test_edit_resources_ignores_cancelled_dialog(monkeypatch: pytest.MonkeyPatch
     app.edit_resources()
 
     # ``dialog.result`` is falsy, so the tree row and player stay unchanged.
-    assert app.current_save.players[0].resources == [10.0, 20.0, 30.0, 40.0]  # nosec B101
+    assert app.current_save.players[0].resources == [
+        10.0,
+        20.0,
+        30.0,
+        40.0,
+    ]  # nosec B101
     assert app.tree.item(item_id)["values"][1] == "10"  # nosec B101
 
 
-def test_save_changes_reuses_existing_backup(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_save_changes_reuses_existing_backup(monkeypatch: pytest.MonkeyPatch,
+                                             tmp_path: Path) -> None:
     gui, _dialog_state, message_calls = install_fake_tk(monkeypatch)
 
     class FakeSave:  # pylint: disable=too-few-public-methods
+
         def __init__(self) -> None:
             self.saved_to = None
 

--- a/tests/test_swgb_save_gui.py
+++ b/tests/test_swgb_save_gui.py
@@ -432,3 +432,76 @@ def test_running_swgb_save_gui_as_main_executes_entrypoint(monkeypatch: pytest.M
     runpy.run_path(str(Path(gui.__file__)), run_name="__main__")
 
     assert root.mainloop_called is True  # nosec B101
+
+
+def test_browse_file_keeps_path_when_dialog_is_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
+    gui, dialog_state, _message_calls = install_fake_tk(monkeypatch)
+    app = gui.SaveGameGUI(gui.tk.Tk())
+    app.file_path.set("previous.ga2")
+
+    # A cancelled dialog returns an empty filename, so the ``if filename`` guard
+    # is False and the existing path is left untouched.
+    dialog_state["filename"] = ""
+    app.browse_file()
+
+    assert app.file_path.get() == "previous.ga2"  # nosec B101
+
+
+def test_edit_resources_ignores_cancelled_dialog(monkeypatch: pytest.MonkeyPatch) -> None:
+    gui, _dialog_state, _message_calls = install_fake_tk(monkeypatch)
+
+    class FakePlayer:  # pylint: disable=too-few-public-methods
+        def __init__(self) -> None:
+            self.name = "Alpha"
+            self.index = 1
+            self.resources = [10.0, 20.0, 30.0, 40.0]
+
+    class FakeSave:  # pylint: disable=too-few-public-methods
+        def __init__(self) -> None:
+            self.players = [FakePlayer()]
+
+    app = gui.SaveGameGUI(gui.tk.Tk())
+    app.current_save = FakeSave()
+    item_id = app.tree.insert("", "end", values=["Alpha (Player 1)", "10", "20", "30", "40"])
+    app.tree.selection_set(item_id)
+
+    class CancelledDialog:  # pylint: disable=too-few-public-methods
+        def __init__(self, *_args, **_kwargs):
+            self.dialog = object()
+            self.result = None
+
+    monkeypatch.setattr(gui, "EditResourceDialog", CancelledDialog)
+    app.edit_resources()
+
+    # ``dialog.result`` is falsy, so the tree row and player stay unchanged.
+    assert app.current_save.players[0].resources == [10.0, 20.0, 30.0, 40.0]  # nosec B101
+    assert app.tree.item(item_id)["values"][1] == "10"  # nosec B101
+
+
+def test_save_changes_reuses_existing_backup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    gui, _dialog_state, message_calls = install_fake_tk(monkeypatch)
+
+    class FakeSave:  # pylint: disable=too-few-public-methods
+        def __init__(self) -> None:
+            self.saved_to = None
+
+        def save(self, filename: str) -> None:
+            self.saved_to = filename
+
+    app = gui.SaveGameGUI(gui.tk.Tk())
+    app.current_save = FakeSave()
+    save_file = tmp_path / "save.ga2"
+    save_file.write_bytes(b"save")
+    backup_file = tmp_path / "save.ga2.backup"
+    backup_file.write_bytes(b"original-backup")
+    app.file_path.set(str(save_file))
+
+    app.save_changes()
+
+    # The backup already exists, so the ``if not os.path.exists`` guard is False
+    # and shutil.copy2 is skipped, leaving the original backup intact.
+    assert backup_file.read_bytes() == b"original-backup"  # nosec B101
+    assert app.current_save.saved_to == str(save_file)  # nosec B101
+    assert message_calls["info"]  # nosec B101


### PR DESCRIPTION
## **User description**
## Summary

Drives this repo toward the Quality-Zero target (100% coverage, zero findings)
using **real fixes only** — no alert dismissals, no coverage `omit` of authored
code.

### 1. 100% branch coverage (8 previously-partial branches)

The canonical coverage command (`python -m pytest --cov=. --cov-branch`, per the
quality-zero-platform repo profile) reported the two source modules at **99% /
98%** because of 8 partial branches. This adds 8 headless tests (mock-Tk, no
display required) covering every one:

**swgb_save.py** (`154->161`, `231->275`, `281->280`, `356->366`, `376->exit`):
- `_name_from_direct_scan` scan loop reaching the `MAX_NAME_BYTES` cap
- `_find_player_entries` / `_rewrite_player_resources` loops exiting via the
  `pos < len-32` window guard (not the `find() == -1` sentinel)
- `_match_player` continuing past already-updated / unknown names
- `_create_backup_if_missing` preserving an existing backup (copy skipped)

**swgb_save_gui.py** (`222->exit`, `285->exit`, `310->314`):
- `browse_file` cancelled dialog leaving the path untouched
- `edit_resources` cancelled edit dialog leaving the row/player unchanged
- `save_changes` reusing a pre-existing backup (`shutil.copy2` skipped)

Result: **100% lines and branches** on all four measured files; 44 -> 52 tests.

### 2. Codacy Python lint findings (real, behavior-preserving fixes)

- **swgb_save_gui.py**: add `from __future__ import absolute_import, division`
  (matches `swgb_save.py` and `scripts/security_helpers.py`). Clears Pylint
  **W1618** (missing absolute_import) and two **W1619** (division without
  `__future__`) on the dialog-centering math. No-op under Python 3.
- **swgb_save.py**: make `_hex_dump` a `@staticmethod` (uses no instance state),
  clearing Pylint **R0201** 'method could be a function'. All `self._hex_dump(...)`
  call sites work unchanged.

## Test plan
- [x] `bash scripts/verify` — 52 passed
- [x] `python -m pytest --cov=. --cov-branch` — TOTAL 100.0% (lines + branches), no missing branches on any file
- [x] `qlty check --all` — ✔ No issues
- [x] `python -m py_compile swgb_save.py swgb_save_gui.py` — clean

## Not in scope (residual)
- Pre-existing non-blocking Codacy **Info** items (markdownlint in docs; some are
  governance-synced `.github/agents/*` / `BRANCH_*.md` files), 2 test-file R0201,
  and 1 Lizard `SaveGameGUI.__init__` length **Warning** — left untouched to keep
  this PR behavior-preserving and tightly scoped.
- `scripts/security_helpers.py` is not in the CI coverage denominator (only
  imported modules are reported under `--cov=.`); a starter test suite is tracked
  as a follow-up rather than risking the 100% gate here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reaches 100% line and branch coverage, clears `Codacy`/`pylint` findings, and standardizes code formatting without behavior changes. Adds eight headless tests to cover previously partial branches in the save logic and Tkinter GUI; all 52 tests pass.

- **Refactors**
  - `swgb_save.py`: make `_hex_dump` a `@staticmethod` (fixes `pylint` R0201).
  - `swgb_save_gui.py`: add `from __future__ import absolute_import, division` (fixes `pylint` W1618/W1619; no-op on Python 3).
  - Format Python files for consistent style across the project (no behavior changes).

<sup>Written for commit 6bfb9c84680132ea0b23ce7b844a1d4908d52850. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Prekzursil/Star-Wars-Galactic-Battlegrounds-Save-Game-Editor/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Add coverage for cancel flows and backup reuse, and clean up Python compatibility warnings

### What Changed
- Added tests for the remaining save-editor edge cases, including cancelled file selection, cancelled resource edits, and saving when a backup already exists
- Added tests for the save parser and rewrite paths that were still untested, bringing branch coverage to 100%
- Kept the GUI and save code compatible with older Python import and division behavior, and marked one helper as a static utility

### Impact
`✅ Fewer regressions in save editing`
`✅ Safer cancel behavior in the file picker and resource editor`
`✅ Full test coverage for save parsing and rewriting` 
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
